### PR TITLE
Add support for custom bundle naming

### DIFF
--- a/lib/cli/custom-bundle.js
+++ b/lib/cli/custom-bundle.js
@@ -12,7 +12,7 @@ var path = require('path');
 
 function bundleCustomPartials() {
   var files = fs.readdirSync(_huron.program.custom);
-  var bundleName = _huron.program.destination + '/custom-bundle.html';
+  var bundleName = _huron.program.destination + '/' + _huron.program.bundleName + '-custom-bundle.html';
   var bundleOutput = fs.createWriteStream(bundleName, 'utf8');
 
   if (files.length) {

--- a/lib/cli/huron-config.js
+++ b/lib/cli/huron-config.js
@@ -12,7 +12,7 @@ function processArgs() {
     return [_huron.cwd, dest].join('/');
   }).option('--custom [custom]', 'location of user-generated [custom] partials', function (custom) {
     return [_huron.cwd, custom].join('/');
-  }).option('--bundle', 'bundle partials into a single file', 'huron').option('--bundle-name', 'name of bundle', 'huron').option('-r, --root [root]', '[root] directory for the server, defaults to current working directory', _huron.cwd).option('--port [port]', '[port] to listen the server on', function (port) {
+  }).option('--bundle', 'bundle partials into a single file').option('--bundle-name [bundleName]', 'name of bundle', 'huron').option('-r, --root [root]', '[root] directory for the server, defaults to current working directory', _huron.cwd).option('--port [port]', '[port] to listen the server on', function (port) {
     return parseInt(port);
   }, 8080).option('-o, --output', 'Verbose output of options').option('--runOnce', 'Run only once, without watching').parse(process.argv);
 

--- a/lib/cli/huron-config.js
+++ b/lib/cli/huron-config.js
@@ -12,7 +12,7 @@ function processArgs() {
     return [_huron.cwd, dest].join('/');
   }).option('--custom [custom]', 'location of user-generated [custom] partials', function (custom) {
     return [_huron.cwd, custom].join('/');
-  }).option('--bundle', 'bundle partials into a single file').option('-r, --root [root]', '[root] directory for the server, defaults to current working directory', _huron.cwd).option('--port [port]', '[port] to listen the server on', function (port) {
+  }).option('--bundle', 'bundle partials into a single file', 'huron').option('--bundle-name', 'name of bundle', 'huron').option('-r, --root [root]', '[root] directory for the server, defaults to current working directory', _huron.cwd).option('--port [port]', '[port] to listen the server on', function (port) {
     return parseInt(port);
   }, 8080).option('-o, --output', 'Verbose output of options').option('--runOnce', 'Run only once, without watching').parse(process.argv);
 

--- a/lib/cli/huron-parse-kss.js
+++ b/lib/cli/huron-parse-kss.js
@@ -13,7 +13,7 @@ var jsdom = require('jsdom'); // JavaScript implementation of the WHATWG DOM and
 
 // Parse KSS and insert into an HTML partial
 function kssTraverse(files) {
-  var bundleName = _huron.program.destination + '/huron-bundle.html';
+  var bundleName = _huron.program.destination + '/' + _huron.program.bundleName + '-bundle.html';
   var bundleOutput = null;
   var kssRoot = Object.keys(files);
 

--- a/lib/cli/init-custom.js
+++ b/lib/cli/init-custom.js
@@ -18,8 +18,6 @@ var Gaze = require('gaze').Gaze; // File watcher
 function initCustom() {
   var gaze = new Gaze(_huron.program.custom + '/*.html');
 
-  console.log(_huron.program);
-
   (0, _customBundle2.default)();
 
   gaze.on('error', function (error) {

--- a/lib/cli/init-custom.js
+++ b/lib/cli/init-custom.js
@@ -18,6 +18,8 @@ var Gaze = require('gaze').Gaze; // File watcher
 function initCustom() {
   var gaze = new Gaze(_huron.program.custom + '/*.html');
 
+  console.log(_huron.program);
+
   (0, _customBundle2.default)();
 
   gaze.on('error', function (error) {

--- a/src/cli/custom-bundle.js
+++ b/src/cli/custom-bundle.js
@@ -5,7 +5,7 @@ import { program } from './huron.js';
 
 export default function bundleCustomPartials() {
   const files = fs.readdirSync(program.custom);
-  const bundleName = `${program.destination}/custom-bundle.html`;
+  const bundleName = `${program.destination}/${program.bundleName}-custom-bundle.html`;
   let bundleOutput = fs.createWriteStream(bundleName, 'utf8');
 
   if (files.length) {

--- a/src/cli/huron-config.js
+++ b/src/cli/huron-config.js
@@ -22,6 +22,11 @@ export default function processArgs() {
       'bundle partials into a single file'
     )
     .option(
+      '--bundle-name [bundleName]',
+      'name of bundle',
+      'huron'
+    )
+    .option(
       '-r, --root [root]',
       '[root] directory for the server, defaults to current working directory',
       cwd

--- a/src/cli/huron-parse-kss.js
+++ b/src/cli/huron-parse-kss.js
@@ -6,7 +6,7 @@ const jsdom = require('jsdom'); // JavaScript implementation of the WHATWG DOM a
 
 // Parse KSS and insert into an HTML partial
 export default function kssTraverse(files) {
-  const bundleName = `${program.destination}/huron-bundle.html`;
+  const bundleName = `${program.destination}/${program.bundleName}-bundle.html`;
   let bundleOutput = null;
   let kssRoot = Object.keys(files);
 


### PR DESCRIPTION
- This is a fix specifically for DFM. 
- Trying to run multiple sites' prototypes using different KSS source (source that can't overlap, and therefore can't be accessed by huron simultaneously) would result in overwriting the bundle, causing all but a single site's prototypes to break.

Note: This should not break existing huron setups **unless** you are using custom bundles, in which case you'll need to change your custom bundle name from `custom-bundle.html` to `huron-custom-bundle.html`