### PR TITLE
Move Huron prototypes to inside the KSS folder

### DIFF
--- a/src/cli/actions.js
+++ b/src/cli/actions.js
@@ -560,6 +560,8 @@ function writeTemplate(id, type, output, content, templates, huron) {
  * @param  {string} content - The content of the file to write.
  * @param  {object} huron - The huron config object.
  * @see writeTemplate()
+ * @todo We can look to this function to load the handlebars templates
+ *       through the webpack loader instead.
  */
 function copyFile(filename, output, content, huron) {
   const outputRelative = path.join(huron.templates, output, `${filename}.html`);

--- a/src/cli/actions.js
+++ b/src/cli/actions.js
@@ -87,7 +87,17 @@ export function updateFile(filepath, sections, templates, huron) {
           writeTemplate(section.referenceURI, output, content, templates, huron);
           resolve(section.referenceURI);
         } else {
-          reject(file.name);
+          // Check if this is a prototype file.
+          const isPrototype =
+            file.dir.indexOf('prototypes') !== -1 &&
+            file.name.indexOf('prototype-') !== -1 ? true : false;
+
+          if(isPrototype) {
+            // If so, copy over to the huron directory.
+            copyFile(file.name, output, content, huron);
+          } else {
+            reject(`Rejected file: ${file.name}`);
+          }
         }
         break;
 
@@ -540,7 +550,26 @@ function writeTemplate(id, type, output, content, templates, huron) {
 
   templates.set(key, `./${outputRelative}`, storeCb);
   fs.outputFileSync(outputPath, content);
-  console.log(`writing ${outputPath}`);
+  console.log(`Writing ${outputPath}`);
+}
+
+/**
+ * Copy an HTML file into the huron output directory.
+ * @param  {string} filename - The name of the file (without extension).
+ * @param  {string} output - The relative path to this file within the huron.kss directory.
+ * @param  {string} content - The content of the file to write.
+ * @param  {object} huron - The huron config object.
+ * @see writeTemplate()
+ */
+function copyFile(filename, output, content, huron) {
+  const outputRelative = path.join(huron.templates, output, `${filename}.html`);
+  const outputPath = path.resolve(cwd, huron.root, outputRelative);
+  try {
+    fs.outputFileSync(outputPath, content);
+  } catch(e) {
+    console.log(filename, outputPath);
+  }
+  console.log(`Copying ${outputPath}`);
 }
 
 /**

--- a/src/cli/huron.js
+++ b/src/cli/huron.js
@@ -30,7 +30,7 @@ const extenstions = [
   '.json'
 ];
 
-// Move huron script into huron roon
+// Move huron script into huron root
 fs.writeFileSync(path.join(cwd, huron.root, 'huron.js'), huronScript);
 
 // Generate watch list for Gaze, start gaze
@@ -39,6 +39,7 @@ extenstions.forEach(ext => {
   gazeWatch.push(`${huron.kss}/**/*${ext}`);
 });
 const gaze = new Gaze(gazeWatch);
+
 
 // Initialize all files watched by gaze
 initFiles(gaze.watched(), sections, templates, huron)
@@ -55,7 +56,7 @@ initFiles(gaze.watched(), sections, templates, huron)
               console.log(`${filepath} updated!`);
             },
             (error) => {
-              console.log(error);
+              console.error('changed', error);
             }
           );
       });
@@ -69,7 +70,7 @@ initFiles(gaze.watched(), sections, templates, huron)
               console.log(`${filepath} added!`);
             },
             (error) => {
-              console.log(error);
+              console.error('update', error);
             }
           );
       });
@@ -84,7 +85,7 @@ initFiles(gaze.watched(), sections, templates, huron)
               console.log(`${newPath} added!`);
             },
             (error) => {
-              console.log(error);
+              console.error('renamed', error);
             }
           );
       });

--- a/src/cli/require-templates.js
+++ b/src/cli/require-templates.js
@@ -8,6 +8,12 @@ export default function requireTemplates(huron, templates, sections) {
   const templateIds = [];
   const outputPath = path.join(cwd, huron.root);
 
+  // Add the prototypes to the template array
+  // These are copied from the huron.kss directory
+  huron.prototypes.forEach(prototype => {
+    templateObj[`prototype-${prototype}`] = `./${huron.templates}/prototypes/prototype-${prototype}.html`;
+  });
+
   // Generate a list of paths and IDs for all templates
   for (let template in templateObj) {
     templatePathArray.push(`'${templateObj[template]}'`);
@@ -45,12 +51,6 @@ export default function requireTemplates(huron, templates, sections) {
       `templates['${template}'] = require('${templateObj[template]}');`
     );
   };
-
-  huron.prototypes.forEach(prototype => {
-    prependScript.push(
-      `templates['prototype-${prototype}'] = require('./${huron.templates}/prototype-${prototype}.html');`
-    )
-  });
 
   fs.outputFileSync(
     path.join(outputPath, 'huron-requires.js'),

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -12,7 +12,7 @@ export function updateFile(filepath, sections, huron) {
   const filename = file.name.replace('_', '');
   let kssSource = null;
 
-  console.log(path.relative(filepath, cwd));
+  console.log('update file', path.relative(filepath, cwd));
 
   switch (file.ext) {
     case '.html':


### PR DESCRIPTION
Instead of editing prototype files from within the root prototype generated directory, it will now 
- copy those files from the `{huron.kss}/prototypes` directory, if they follow the convention `protototype-{name}.html`, and 
- include those templates in hot module reloading 🔥 

This means we can edit all our templates from our KSS directory.
