### PR TITLE
Load/reload markup from modules object only

### DIFF
--- a/src/cli/actions.js
+++ b/src/cli/actions.js
@@ -60,6 +60,10 @@ export function updateFile(filepath, store) {
   const file = path.parse(filepath);
   let section = null;
 
+  if (filepath.indexOf(huron.get('sectionTemplate')) !== -1) {
+      return utils.writeSectionTemplate(filepath, store);
+  }
+
   switch (file.ext) {
     // Plain HTML template, external
     case '.html':

--- a/src/cli/handle-kss.js
+++ b/src/cli/handle-kss.js
@@ -159,6 +159,16 @@ kssHandler.updateReferenceURI = function(file, oldSection, section, store) {
     if (isInline) {
       utils.removeFile(oldSection.referenceURI, 'template', filepath, store);
     }
+
+    ['data', 'markup'].forEach((field) => {
+      if (oldSection[field]) {
+        const filepath = path.join(file.dir, oldSection[field]);
+
+        newStore = templateHandler.deleteTemplate(filepath, oldSection, newStore);
+        newStore = templateHandler.updateTemplate(filepath, section, newStore);
+      }
+    });
+
     // Remove old section data
     utils.removeFile(
       oldSection.referenceURI,
@@ -167,15 +177,6 @@ kssHandler.updateReferenceURI = function(file, oldSection, section, store) {
       store
     );
   }
-
-  ['data', 'markup'].forEach((field) => {
-    if (oldSection[field]) {
-      const filepath = path.join(file.dir, oldSection[field]);
-
-      newStore = templateHandler.deleteTemplate(filepath, oldSection, newStore);
-      newStore = templateHandler.updateTemplate(filepath, section, newStore);
-    }
-  });
 
   return newStore
     .setIn(

--- a/src/cli/handle-templates.js
+++ b/src/cli/handle-templates.js
@@ -1,10 +1,11 @@
-const cwd = process.cwd(); // Current working directory
-const path = require('path');
-const fs = require('fs-extra');
-
 import { utils } from './utils';
 
 export const templateHandler = {};
+
+const cwd = process.cwd(); // Current working directory
+const path = require('path');
+const fs = require('fs-extra');
+const chalk = require('chalk')
 
 /**
  * Handle update of a template or data (json) file
@@ -19,24 +20,36 @@ templateHandler.updateTemplate = function(filepath, section, store) {
   const dest = path.resolve(cwd, huron.get('output'));
   const pairPath = utils.getTemplateDataPair(file, section, store);
   const type = '.json' === file.ext ? 'data' : 'template';
-  let content = fs.readFileSync(filepath, 'utf8');
+  let content = false;
 
-  let requirePath = utils.writeFile(section.referenceURI, type, filepath, content, store);
-  section[`${type}Path`] = requirePath;
+  try {
+    content = fs.readFileSync(filepath, 'utf8');
+  } catch(e) {
+    console.log(chalk.red(`${filepath} does not exist`));
+  }
 
-  return store
-    .setIn(
-      ['templates', requirePath],
-      pairPath
-    )
-    .setIn(
-      ['sections', 'sectionsByPath', section.kssPath],
-      section
-    )
-    .setIn(
-      ['sections', 'sectionsByURI', section.referenceURI],
-      section
-    );
+
+  if (content) {
+    let requirePath = utils.writeFile(section.referenceURI, type, filepath, content, store);
+    section[`${type}Path`] = requirePath;
+
+    return store
+      .setIn(
+        ['templates', requirePath],
+        pairPath
+      )
+      .setIn(
+        ['sections', 'sectionsByPath', section.kssPath],
+        section
+      )
+      .setIn(
+        ['sections', 'sectionsByURI', section.referenceURI],
+        section
+      );
+  } else {
+    console.log('hey');
+    return store;
+  }
 }
 
 /**

--- a/src/cli/huron.js
+++ b/src/cli/huron.js
@@ -96,6 +96,6 @@ if (!program.production) {
 }
 
 // Start webpack or build for production
-// startWebpack(config);
+startWebpack(config);
 
 

--- a/src/cli/huron.js
+++ b/src/cli/huron.js
@@ -21,10 +21,6 @@ import startWebpack from './server';
 const localConfig = require(path.join(cwd, program.config));
 const config = generateConfig(localConfig);
 const huron = config.huron;
-const sectionTemplate = utils.wrapMarkup(
-  fs.readFileSync(path.resolve(__dirname, huron.sectionTemplate), 'utf8'),
-  'section'
-);
 const extenstions = [
   huron.kssExtension,
   '.html',
@@ -53,14 +49,9 @@ const dataStructure = Immutable.Map({
 });
 let store = null; // All updates to store will be here
 
-// Move huron script and section template into huron root
-fs.outputFileSync(
-  path.join(cwd, huron.root, huron.output, 'huron-sections/sections.hbs'),
-  sectionTemplate
-);
-
 // Generate watch list for Gaze, start gaze
 const gazeWatch = [];
+gazeWatch.push(path.resolve(__dirname, huron.sectionTemplate));
 extenstions.forEach(ext => {
   gazeWatch.push(`${huron.kss}/**/*${ext}`);
 });

--- a/src/cli/require-templates.js
+++ b/src/cli/require-templates.js
@@ -61,22 +61,20 @@ if (module.hot) {
 }\n`
 
   const append = `
-  function hotReplace(key, module, modules, store) {
-    insert.store = store;
-    insert.modules = modules;
-    insert.loadModule(key, module);
-  }
+function hotReplace(key, module, modules, store) {
+  insert.modules = modules;
+  insert.loadModule(key, module);
+}
 
-  function updateStore(data) {
-    store = data.store;
-    changed = data.changed;
-    insert.store = store;
+function updateStore(data) {
+  store = data.store;
+  changed = data.changed;
+  insert.store = store;
 
-    if (changed) {
-      insert.updateChangedSection(changed);
-    }
+  if (changed) {
+    insert.updateChangedSection(changed);
   }
-  `
+}\n`
 
   // Write the contents of thsi script.
   fs.outputFileSync(
@@ -99,7 +97,7 @@ export const writeStore = function(store, changed = false) {
   fs.outputFileSync(
     path.join(outputPath, 'huron-store.js'),
     `module.exports.store = ${JSON.stringify(store.toJSON())}
-    module.exports.changed = '${changed}'\n`
+module.exports.changed = '${changed}'\n`
   );
 }
 

--- a/src/cli/require-templates.js
+++ b/src/cli/require-templates.js
@@ -61,12 +61,8 @@ if (module.hot) {
   const append = `
 function hotReplace(key, module, modules) {
   insert.modules = modules;
-  if (module === store.sectionTemplatePath) {
-    insert.cycleModules(document, false, {
-      property: 'type',
-      values: ['section'],
-      include: true,
-    });
+  if (key === store.sectionTemplatePath) {
+    insert.cycleSections();
   } else {
     insert.loadModule(document, key, module);
   }

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -107,7 +107,7 @@ utils.writeFile = function(id, type, filepath, content, store) {
   const outputRelative = path.join(huron.get('output'), componentPath, `${filename}`);
   const outputPath = path.resolve(cwd, huron.get('root'), outputRelative);
 
-  if ('data' !== type) {
+  if ('data' !== type && 'section' !== type) {
     content = utils.wrapMarkup(content, id);
   }
 
@@ -146,21 +146,30 @@ utils.removeFile = function(id, type, filepath, store) {
   return `./${outputRelative.replace(`${huron.get('output')}/`, '')}`;;
 }
 
+/**
+ * Write a template for sections
+ *
+ * @param  {string} filepath - the original template file
+ * @param  {object} store - data store
+ *
+ * @return {object} updated store
+ */
 utils.writeSectionTemplate = function(filepath, store) {
   const huron = store.get('config');
   const sectionTemplate = utils.wrapMarkup(fs.readFileSync(filepath, 'utf8'));
+  const componentPath = './huron-sections/sections.hbs';
   const output = path.join(
     cwd,
     huron.get('root'),
     huron.get('output'),
-    'huron-sections/sections.hbs'
+    componentPath
   );
 
   // Move huron script and section template into huron root
   fs.outputFileSync(output, sectionTemplate);
   console.log(chalk.green(`writing section template to ${output}`));
 
-  return store.set('sectionTemplatePath', './huron-sections/section.hbs');;
+  return store.set('sectionTemplatePath', componentPath);
 }
 
 /**

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -146,6 +146,23 @@ utils.removeFile = function(id, type, filepath, store) {
   return `./${outputRelative.replace(`${huron.get('output')}/`, '')}`;;
 }
 
+utils.writeSectionTemplate = function(filepath, store) {
+  const huron = store.get('config');
+  const sectionTemplate = utils.wrapMarkup(fs.readFileSync(filepath, 'utf8'));
+  const output = path.join(
+    cwd,
+    huron.get('root'),
+    huron.get('output'),
+    'huron-sections/sections.hbs'
+  );
+
+  // Move huron script and section template into huron root
+  fs.outputFileSync(output, sectionTemplate);
+  console.log(chalk.green(`writing section template to ${output}`));
+
+  return store.set('sectionTemplatePath', './huron-sections/section.hbs');;
+}
+
 /**
  * Request for section data based on section reference
  *

--- a/src/js/huron.js
+++ b/src/js/huron.js
@@ -61,10 +61,8 @@ class InsertNodes {
         if (currentTag.childNodes.length === 0) {
           const meta = this.getMetaFromTag(currentTag);
 
-          if (meta.key) {
+          if (meta) {
             this.replaceTemplate(meta);
-          } else {
-            console.warn(`Could not find module for ${meta.id} or this module cannot be hot reloaded`);
           }
         }
       }
@@ -80,15 +78,13 @@ class InsertNodes {
   loadModule(key, module) {
     const meta = this.getMetaFromPath(key);
 
-    if (meta.id) {
+    if (meta) {
       // Use a special function if we've updated the template used for all sections
       if ('sections-template' !== meta.type) {
         this.replaceTemplate(meta);
       } else {
         this.replaceSections();
       }
-    } else {
-      console.warn(`Could not find module ${meta.id} or this module cannot be hot reloaded`);
     }
   }
 
@@ -103,10 +99,8 @@ class InsertNodes {
         const currentSection = sectionTags.item(i);
         const meta = this.getMetaFromTag(currentSection);
 
-        if (meta.key) {
+        if (meta) {
           this.replaceTemplate(meta);
-        } else {
-          console.warn(`Could not find module ${meta.id} or this module cannot be hot reloaded`);
         }
       }
     }
@@ -227,7 +221,11 @@ class InsertNodes {
       return Object.assign({id, type, key, module}, renderData);
     }
 
-    return {id};
+    console.warn(`Could not find module or this module cannot be hot reloaded
+      type: '${type}'
+      section: '${id}'
+    `);
+    return false;
   }
 
   /**
@@ -275,7 +273,8 @@ class InsertNodes {
       return Object.assign({id, type, key, module}, renderData);
     }
 
-    return {key};
+    console.warn(`Could not find module '${key}' or this module cannot be hot reloaded`);
+    return false;
   }
 
   /**

--- a/src/js/huron.js
+++ b/src/js/huron.js
@@ -147,7 +147,10 @@ class InsertNodes {
    * @param {object} meta - Module metadata
    */
   replaceTemplate(context, meta) {
-    let tags = context.querySelectorAll(`[data-huron-id="${meta.id}"][data-huron-type="${meta.type}"]`);
+    let tags = null;
+
+    meta.type = this.validateType(meta.type);
+    tags = context.querySelectorAll(`[data-huron-id="${meta.id}"][data-huron-type="${meta.type}"]`);
 
     if (tags && meta.render) {
       for (let i = 0; i < tags.length; i++) {
@@ -291,15 +294,18 @@ class InsertNodes {
   /**
    * Verify specified element is using an acceptable huron type
    *
-   * @param  {HTMLElement} element - Html element to check huron type
+   * @param  {string} type - type of partial
+   *                         (template, data, description, section or prototype )
    *
    * @return {string} - huron type or 'template' if invalid
    */
-  validateType(element) {
-    const type = element.dataset.huronType;
+  validateType(type) {
+    if ('data' === type) {
+      return 'template';
+    }
 
     if (!this._types.includes(type)) {
-      return 'template';
+      return false;
     }
 
     return type;

--- a/src/js/huron.js
+++ b/src/js/huron.js
@@ -24,7 +24,10 @@ class InsertNodes {
 
     // Inits
     this.cycleEls(document);
+    this.cycleStyleguide();
+  }
 
+  cycleStyleguide() {
     // Sections
     const sectionsQuery = document.querySelector('[huron-sections]');
     if (sectionsQuery) {
@@ -146,7 +149,7 @@ class InsertNodes {
       tags = document.querySelectorAll(`[data-huron-id="${meta.id}"]:not([data-huron-type])`);
     }
 
-    if (tags) {
+    if (tags && meta.render) {
       for (let i = 0; i < tags.length; i++) {
         let currentTag = tags.item(i);
         let modifier = currentTag.dataset.huronModifier;
@@ -169,6 +172,12 @@ class InsertNodes {
 
         this.cycleEls(currentTag, meta.id);
       }
+    } else {
+      console.warn(
+        `Could not render module
+        section: ${meta.id}
+        type: ${meta.type}`
+      );
     }
   }
 
@@ -196,7 +205,7 @@ class InsertNodes {
       if (sections[id] && sections[id].hasOwnProperty(field)) {
         key = sections[id][field];
       } else {
-        console.log(`Failed to find template or section '${id}' does not exist`);
+        console.warn(`Failed to find template or section '${id}' does not exist`);
       }
     } else if ('prototype' === type) {
       for (let prototype in this._prototypes) {
@@ -210,7 +219,7 @@ class InsertNodes {
         data = sections[id];
         key = `./huron-sections/sections.hbs`;
       } else {
-        console.log(`Section '${id}' does not exist`);
+        console.warn(`Section '${id}' does not exist`);
       }
     }
 

--- a/templates/section.hbs
+++ b/templates/section.hbs
@@ -6,6 +6,10 @@
 
 	<!-- markup -->
 	{{#each modifiers}}
-		<div data-huron-id="{{ ../referenceURI }}" data-huron-modifier="{{ this.name }}" class="{{ this.className }}"></div>
+		<div data-huron-id="{{ ../referenceURI }}"
+			data-huron-type="template"
+			data-huron-modifier="{{ this.name }}"
+			class="{{ this.className }}">
+		</div>
 	{{/each}}
 </section>


### PR DESCRIPTION
This greatly simplifies how we're replacing markup. Before, on initial load we were starting with HTML tags, then on HMR reload we were starting from module object. Now we're _only_ going from modules, making both load and reload follow the same process.

* Also fixes bugs with sort/unsort of sections
* Moves all code related to changes in KSS reference URI to a single function