### PR TITLE
Only change the public path when the process is hot reloading

### DIFF
--- a/src/cli/generate-config.js
+++ b/src/cli/generate-config.js
@@ -3,8 +3,10 @@ const path = require('path');
 const fs = require('fs-extra');
 const cwd = process.cwd();
 const HTMLWebpackPlugin = require('html-webpack-plugin');
+const isHot = 'dev' === process.env.npm_lifecycle_event;
 import { defaultConfig } from '../../config/webpack.config.js';
 import { program } from './parse-args';
+
 
 /**
  * Generate a mutant hybrid of the huron default webpack config and your local webpack config
@@ -83,7 +85,9 @@ export default function generateConfig(config) {
   delete config.devServer;
 
   // Set publicPath
-  config.output.publicPath = `http://localhost:8080/${huron.root}`;
+  if (isHot) {
+    config.output.publicPath = `http://localhost:${huron.port}/${huron.root}`;
+  }
 
   return config;
 }

--- a/src/cli/generate-config.js
+++ b/src/cli/generate-config.js
@@ -1,12 +1,10 @@
+import { defaultConfig } from '../../config/webpack.config.js';
+import { program } from './parse-args';
 const webpack = require('webpack');
 const path = require('path');
 const fs = require('fs-extra');
 const cwd = process.cwd();
 const HTMLWebpackPlugin = require('html-webpack-plugin');
-const isHot = 'dev' === process.env.npm_lifecycle_event;
-import { defaultConfig } from '../../config/webpack.config.js';
-import { program } from './parse-args';
-
 
 /**
  * Generate a mutant hybrid of the huron default webpack config and your local webpack config
@@ -85,7 +83,7 @@ export default function generateConfig(config) {
   delete config.devServer;
 
   // Set publicPath
-  if (isHot) {
+  if (!program.production) {
     config.output.publicPath = `http://localhost:${huron.port}/${huron.root}`;
   } else {
     config.output.publicPath = '';

--- a/src/cli/generate-config.js
+++ b/src/cli/generate-config.js
@@ -87,6 +87,8 @@ export default function generateConfig(config) {
   // Set publicPath
   if (isHot) {
     config.output.publicPath = `http://localhost:${huron.port}/${huron.root}`;
+  } else {
+    config.output.publicPath = '';
   }
 
   return config;

--- a/src/cli/require-templates.js
+++ b/src/cli/require-templates.js
@@ -16,7 +16,7 @@ let store = huronData.store;
 let changed = huronData.changed;
 
 const assets = require.context(
-  '${path.join(cwd, huron.get('root'), huron.get('output'))}',
+  '${path.join('./', huron.get('root'), huron.get('output'))}',
   true,
   /\.(html|json|${huron.get('templates').extension.replace('.', '')})/
 );
@@ -31,7 +31,7 @@ if (module.hot) {
     assets.id,
     () => {
       const newAssets = require.context(
-        '${path.join(cwd, huron.get('root'), huron.get('output'))}',
+        '${path.join('./', huron.get('root'), huron.get('output'))}',
         true,
         /\.(html|json|${huron.get('templates').extension.replace('.', '')})/
       );


### PR DESCRIPTION
So that we can still build files and serve them out of the wp-content directory.