### PR TITLE
Change the require path.

### DIFF
--- a/src/cli/require-templates.js
+++ b/src/cli/require-templates.js
@@ -14,7 +14,7 @@ export const requireTemplates = function(store) {
 let store = require('./huron-store.js');
 
 const assets = require.context(
-  '${path.join('./', huron.get('root'), huron.get('output'))}',
+  '${path.join(huron.get('root'), './' + huron.get('output'))}',
   true,
   /\.(html|json|${huron.get('templates').extension.replace('.', '')})/
 );
@@ -29,7 +29,7 @@ if (module.hot) {
     assets.id,
     () => {
       const newAssets = require.context(
-        '${path.join('./', huron.get('root'), huron.get('output'))}',
+        '${path.join('./', huron.get('root'), './' + huron.get('output'))}',
         true,
         /\.(html|json|${huron.get('templates').extension.replace('.', '')})/
       );


### PR DESCRIPTION
1) looks like we don’t need `huron.root` in the require path, which makes sense as it’s in the public path
2) `path.join` will remove the `./`, which is necessary for a require statement for whatever reason

so we need to change it to `'./${huron.get('output')}',`