### PR TITLE
Adds options to the default stats object.

### DIFF
--- a/src/cli/server.js
+++ b/src/cli/server.js
@@ -23,7 +23,17 @@ export default function startWebpack(config) {
       hot: true,
       quiet: false,
       noInfo: false,
-      stats: {colors: true},
+      stats: {
+        colors: true,
+        hash: false,
+        version: false,
+        assets: false,
+        chunks: false,
+        modules: false,
+        reasons: false,
+        children: false,
+        source: false,
+      },
       contentBase: huron.root,
       publicPath: `http://localhost:${huron.port}/${huron.root}`,
     });


### PR DESCRIPTION
This way it will only output that the modules are building and the time it took to build them and not every single module that has changed. So it is easier to see the linter messages.