### PR TITLE
Check for placeholders that actually exist in the markup...

### DIFF
--- a/src/cli/actions.js
+++ b/src/cli/actions.js
@@ -90,7 +90,7 @@ export function updateFile(filepath, store) {
       if (section) {
         return templateHandler.updateTemplate(filepath, section, store);
       } else {
-        console.log(chalk.red(`No pairing (data or template) file was found for template ${filepath}`));
+        console.log(chalk.red(`Could not find associated KSS section for ${filepath}`));
       }
       break;
 

--- a/src/cli/generate-config.js
+++ b/src/cli/generate-config.js
@@ -223,6 +223,9 @@ function moveAdditionalAssets(assets, subdir = '', huron) {
     const assetURL = url.parse(asset);
     const sourcePath = path.join(cwd, asset);
     const outputPath = path.resolve(cwd, huron.root, subdir, assetInfo.base);
+    const loadPath = program.production ?
+      path.join(subdir, assetInfo.base) :
+      path.join('/', subdir, assetInfo.base); // Use absolute path in development
     let contents = false;
 
     if (
@@ -237,7 +240,7 @@ function moveAdditionalAssets(assets, subdir = '', huron) {
 
       if (contents) {
         fs.outputFileSync(outputPath, contents);
-        assetResults.push(path.join('/', subdir, assetInfo.base));
+        assetResults.push(loadPath);
       }
     } else {
       assetResults.push(asset);

--- a/src/cli/handle-html.js
+++ b/src/cli/handle-html.js
@@ -30,7 +30,7 @@ htmlHandler.updateTempate = function(filepath, section, store) {
     newSection.templateContent = content;
 
     // Rewrite section data with template content
-    utils.writeSectionData(store, newSection);
+    newSection.sectionPath = utils.writeSectionData(store, newSection);
 
     return store
       .setIn(

--- a/src/cli/handle-kss.js
+++ b/src/cli/handle-kss.js
@@ -19,7 +19,8 @@ export const kssHandler = {};
 kssHandler.updateKSS = function(filepath, store) {
   const kssSource = fs.readFileSync(filepath, 'utf8');
   const huron = store.get('config');
-  const oldData = utils.getSection(filepath, false, store);
+  const oldSection = utils.getSection(filepath, false, store) || {};
+  const file = path.parse(filepath);
   let newStore = store;
 
   if (kssSource) {
@@ -27,7 +28,18 @@ kssHandler.updateKSS = function(filepath, store) {
 
     if (styleguide.data.sections.length) {
       let section = utils.normalizeSectionData(styleguide.data.sections[0]);
-      newStore = kssHandler.updateSectionData(section, filepath, store);
+
+      // Update or add section data
+      newStore = kssHandler.updateSectionData(filepath, section, oldSection, newStore);
+
+      // Remove old section data if reference URI has changed
+      if (oldSection &&
+        oldSection.referenceURI &&
+        oldSection.referenceURI !== section.referenceURI
+      ) {
+        newStore = this.unsetSection(oldSection, file, newStore, false);
+      }
+
       writeStore(newStore);
       console.log(chalk.green(`KSS section ${section.referenceURI} file ${filepath} changed or added`));
       return newStore;
@@ -36,9 +48,10 @@ kssHandler.updateKSS = function(filepath, store) {
       return newStore;
     }
   } else {
-    if (oldData) {
-      newStore = kssHandler.deleteKSS(filepath, oldData, store);
+    if (oldSection) {
+      newStore = kssHandler.deleteKSS(filepath, oldSection, newStore);
     }
+
     console.log(chalk.red(`${filepath} not found or empty`));
     return newStore;
   }
@@ -52,20 +65,67 @@ kssHandler.updateKSS = function(filepath, store) {
  * @param {object} store - memory store
  */
 kssHandler.deleteKSS = function(filepath, section, store) {
-  const isInline = section.markup.match(/<\/[^>]*>/) !== null;
   const huron = store.get('config');
   const file = path.parse(filepath);
 
-  // Remove associated inline template
+  // Remove section data from memory store
+  return kssHandler.unsetSection(section, file, store, true);
+}
+
+/**
+ * Update the sections store with new data for a specific section
+ *
+ * @param {object} section - contains updated section data
+ * @param {string} kssPath - path to KSS section
+ * @param {object} store - memory store
+ */
+kssHandler.updateSectionData = function(kssPath, section, oldSection, store) {
+  const huron = store.get('config');
+  const sectionMarkup = section.markup;
+  const sectionFileInfo = path.parse(kssPath);
+  const dataFilepath = path.join(sectionFileInfo.dir, `${sectionFileInfo.name}.json`);
+  const isInline = section.markup.match(/<\/[^>]*>/) !== null;
+  const newSort = kssHandler.sortSection(
+    store.getIn(['sections', 'sorted']),
+    section.reference,
+    store.get('referenceDelimiter')
+  );
+  let newSection = Object.assign({}, oldSection, section);
+  let newStore = store;
+
+  // Required for reference from templates and data
+  newSection.kssPath = kssPath;
+
   if (isInline) {
-    utils.removeFile(section.referenceURI, 'template', filepath, store);
+    // Set section value if inlineTempalte() returned a path
+    newStore = kssHandler.updateInlineTemplate(kssPath, oldSection, newSection, newStore);
+  } else {
+    // Update markup and data fields
+    newStore = kssHandler.updateTemplateFields(sectionFileInfo, oldSection, newSection, newStore);
   }
 
-  // Remove description template
-  utils.removeFile(section.referenceURI, 'description', filepath, store);
+  // Output section description
+  newStore = kssHandler.updateDescription(kssPath, oldSection, newSection, newStore);
 
-  // Remove section data from memory store
-  return kssHandler.unsetSection(section, filepath, store);
+  // Output section data to a JSON file
+  newSection.sectionPath = utils.writeSectionData(newStore, newSection, dataFilepath);
+
+  console.log(oldSection, newSection);
+
+  // Update section sorting
+  return newStore
+    .setIn(
+      ['sections', 'sorted'],
+      newSort
+    )
+    .setIn(
+      ['sections', 'sectionsByPath', kssPath],
+      newSection
+    )
+    .setIn(
+      ['sections', 'sectionsByURI', section.referenceURI],
+      newSection
+    )
 }
 
 /**
@@ -78,11 +138,11 @@ kssHandler.deleteKSS = function(filepath, section, store) {
  * @return {mixed} output template path or false
  */
 kssHandler.updateInlineTemplate = function(filepath, oldSection, section, store) {
-  const isInline = section.markup.match(/<\/[^>]*>/) !== null;
   const newSection = section;
+  let newStore = store;
 
   // If we have inline markup
-  if (isInline) {
+  if (this.fieldShouldOutput(oldSection, section, 'markup')) {
     newSection.templatePath = utils.writeFile(
       section.referenceURI,
       'template',
@@ -91,9 +151,19 @@ kssHandler.updateInlineTemplate = function(filepath, oldSection, section, store)
       store
     );
     newSection.templateContent = section.markup;
+
+    return newStore
+      .setIn(
+        ['sections', 'sectionsByPath', filepath],
+        newSection
+      )
+      .setIn(
+        ['sections', 'sectionsByURI', section.referenceURI],
+        newSection
+      )
   }
 
-  return newSection;
+  return newStore;
 }
 
 /**
@@ -106,14 +176,10 @@ kssHandler.updateInlineTemplate = function(filepath, oldSection, section, store)
  */
 kssHandler.updateDescription = function(filepath, oldSection, section, store) {
   const newSection = section;
+  let newStore = store;
 
   // If we don't have previous KSS or the KSS has been updated
-  if ((oldSection &&
-        (oldSection.description !== section.description ||
-          oldSection.referenceURI !== section.referenceURI)
-    ) ||
-    !oldSection
-  ) {
+  if (this.fieldShouldOutput(oldSection, section, 'description')) {
     // Write new description
     newSection.descriptionPath = utils.writeFile(
       section.referenceURI,
@@ -122,135 +188,106 @@ kssHandler.updateDescription = function(filepath, oldSection, section, store) {
       section.description,
       store
     );
+
+    return newStore
+      .setIn(
+        ['sections', 'sectionsByPath', filepath],
+        newSection
+      )
+      .setIn(
+        ['sections', 'sectionsByURI', section.referenceURI],
+        newSection
+      )
   }
 
-  return newSection;
+  return newStore;
 }
 
 /**
- * Handle output of section description
+ * Handle Data and Markup fields
  *
  * @param {string} file - File data for KSS file from path.parse()
- * @param {object} oldSection - outdate KSS data
+ * @param {object} oldSection - outdated KSS data
  * @param {object} section - KSS section data
  * @param {object} store - memory store
  *
  * @return {object} KSS section data with updated asset paths
  */
-kssHandler.updateReferenceURI = function(file, oldSection, section, store) {
-  const isInline = section.markup.match(/<\/[^>]*>/) !== null;
-  const filepath = path.format(file);
-  const huron = store.get('config');
+kssHandler.updateTemplateFields = function(file, oldSection, section, store) {
+  const kssPath = path.format(file);
   const newSection = section;
-  const dataFilepath = path.join(file.dir, `${file.name}.json`);
+  let filepath = '';
+  let oldFilepath = '';
   let newStore = store;
-  let newSort = kssHandler.sortSection(
-    store.getIn(['sections', 'sorted']),
-    section.reference,
-    store.get('referenceDelimiter')
-  );
 
-  if (
-    oldSection.hasOwnProperty('referenceURI') &&
-    oldSection.referenceURI !== newSection.referenceURI
-  ) {
-    newSort = kssHandler.unsortSection(
-      newSort,
-      oldSection.reference,
-      store.get('referenceDelimiter')
-    );
-    // Remove old description if referenceURI has changed
-    utils.removeFile(oldSection.referenceURI, 'description', filepath, store);
-    // Remove old inline template if referenceURI has changed
-    if (isInline) {
-      utils.removeFile(oldSection.referenceURI, 'template', filepath, store);
-    }
-
-    ['data', 'markup'].forEach((field) => {
+  ['data', 'markup'].forEach((field) => {
+    if (newSection[field]) {
       if (oldSection[field]) {
-        const filepath = path.join(file.dir, oldSection[field]);
-
-        newStore = templateHandler.deleteTemplate(filepath, oldSection, newStore);
-        newStore = templateHandler.updateTemplate(filepath, section, newStore);
+        oldFilepath = path.join(file.dir, oldSection[field]);
+        newStore = templateHandler.deleteTemplate(oldFilepath, oldSection, newStore);
       }
-    });
 
-    // Remove old section data
-    utils.removeFile(
-      oldSection.referenceURI,
-      'section',
-      dataFilepath,
-      store
-    );
-  }
+      filepath = path.join(file.dir, newSection[field]);
+      newStore = templateHandler.updateTemplate(filepath, newSection, newStore);
+    } else {
+      delete newSection[field];
+      newStore = newStore
+        .setIn(
+          ['sections', 'sectionsByPath', kssPath],
+          newSection
+        )
+        .setIn(
+          ['sections', 'sectionsByURI', newSection.referenceURI],
+          newSection
+        )
+    }
+  });
 
-  return newStore
-    .setIn(
-      ['sections', 'sorted'],
-      newSort
-    );
-}
-
-/**
- * Update the sections store with new data for a specific section
- *
- * @param {object} section - contains updated section data
- * @param {string} kssPath - path to KSS section
- * @param {object} store - memory store
- */
-kssHandler.updateSectionData = function(section, kssPath, store) {
-  const huron = store.get('config');
-  const oldSection = utils.getSection(kssPath, false, store) || {};
-  const sectionMarkup = section.markup;
-  const sectionFileInfo = path.parse(kssPath);
-  const dataFilepath = path.join(sectionFileInfo.dir, `${sectionFileInfo.name}.json`);
-  let newSection = Object.assign({}, oldSection, section);
-  let newStore = store;
-
-  // Required for reference from templates and data
-  newSection.kssPath = kssPath;
-
-  // Set section value if inlineTempalte() returned a path
-  newSection = kssHandler.updateInlineTemplate(kssPath, oldSection, newSection, newStore);
-
-  // Output section description
-  newSection = kssHandler.updateDescription(kssPath, oldSection, newSection, newStore);
-
-  // Output section data to a JSON file
-  newSection.sectionPath = utils.writeSectionData(store, newSection, dataFilepath);
-
-  // Output new version of non-inline templates and data
-  // if section URI was changed (as those files are written using referenceURI)
-  newStore = kssHandler.updateReferenceURI(sectionFileInfo, oldSection, section, store);
-
-  // Update section sorting
-  return newStore
-    .setIn(
-      ['sections', 'sectionsByPath', kssPath],
-      newSection
-    )
-    .setIn(
-      ['sections', 'sectionsByURI', section.referenceURI],
-      newSection
-    )
+  return newStore;
 }
 
 /**
  * Remove a section from the memory store
  *
  * @param {object} section - contains updated section data
- * @param {string} kssPath - path to KSS section
+ * @param {string} file - file object from path.parse()
  * @param {object} store - memory store
+ * @param {bool}   removed - has the file been removed or just the section information changed?
  */
-kssHandler.unsetSection = function(section, kssPath, store) {
+kssHandler.unsetSection = function(section, file, store, removed) {
   const sorted = store.getIn(['sections', 'sorted']);
+  const kssPath = path.format(file);
+  const dataFilepath = path.join(file.dir, `${file.name}.json`);
+  const isInline = section.markup.match(/<\/[^>]*>/) !== null;
   const newSort = kssHandler.unsortSection(
     sorted,
     section.reference,
     store.get('referenceDelimiter')
   );
-  return store
-    .deleteIn(['sections', 'sectionsByPath', kssPath])
+  let newStore = store;
+
+  // Remove old section data
+  utils.removeFile(
+    section.referenceURI,
+    'section',
+    dataFilepath,
+    newStore
+  );
+
+   // Remove associated inline template
+  if (isInline) {
+    utils.removeFile(section.referenceURI, 'template', kssPath, newStore);
+  }
+
+  // Remove description template
+  utils.removeFile(section.referenceURI, 'description', kssPath, newStore);
+
+  // Remove data from sectionsByPath if file has been removed
+  if (removed) {
+    newStore = newStore.deleteIn(['sections', 'sectionsByPath', kssPath]);
+  }
+
+  return newStore
     .deleteIn(['sections', 'sectionsByURI', section.referenceURI])
     .setIn(['sections', 'sorted'], newSort);
 }
@@ -275,6 +312,7 @@ kssHandler.sortSection = function(sorted, reference, delimiter) {
   } else {
     sorted[parts[0]] = newSort;
   }
+
   return sorted;
 }
 
@@ -302,4 +340,12 @@ kssHandler.unsortSection = function(sorted, reference, delimiter) {
   }
 
   return sorted;
+}
+
+kssHandler.fieldShouldOutput = function(oldSection, newSection, field) {
+  return (oldSection &&
+      (oldSection[field] !== newSection[field] ||
+      oldSection.referenceURI !== newSection.referenceURI)
+    ) ||
+    ! oldSection;
 }

--- a/src/cli/handle-kss.js
+++ b/src/cli/handle-kss.js
@@ -110,8 +110,6 @@ kssHandler.updateSectionData = function(kssPath, section, oldSection, store) {
   // Output section data to a JSON file
   newSection.sectionPath = utils.writeSectionData(newStore, newSection, dataFilepath);
 
-  console.log(oldSection, newSection);
-
   // Update section sorting
   return newStore
     .setIn(

--- a/src/cli/handle-kss.js
+++ b/src/cli/handle-kss.js
@@ -340,6 +340,14 @@ kssHandler.unsortSection = function(sorted, reference, delimiter) {
   return sorted;
 }
 
+/**
+ * Compare a KSS field between old and new KSS data to see if we need to output
+ * a new module for that field
+ *
+ * @param {object} oldSection - currently sorted sections
+ * @param {object} newSection - reference URI of section to sort
+ * @param {string} field - KSS field to check
+ */
 kssHandler.fieldShouldOutput = function(oldSection, newSection, field) {
   return (oldSection &&
       (oldSection[field] !== newSection[field] ||

--- a/src/cli/handle-templates.js
+++ b/src/cli/handle-templates.js
@@ -20,7 +20,8 @@ templateHandler.updateTemplate = function(filepath, section, store) {
   const dest = path.resolve(cwd, huron.get('output'));
   const pairPath = utils.getTemplateDataPair(file, section, store);
   const type = '.json' === file.ext ? 'data' : 'template';
-  let newSection = section;
+  const newSection = section;
+  let newStore = store;
   let content = false;
 
   try {
@@ -30,32 +31,32 @@ templateHandler.updateTemplate = function(filepath, section, store) {
   }
 
   if (content) {
-    let requirePath = utils.writeFile(section.referenceURI, type, filepath, content, store);
+    let requirePath = utils.writeFile(newSection.referenceURI, type, filepath, content, newStore);
     newSection[`${type}Path`] = requirePath;
 
     if ('template' === type) {
       newSection.templateContent = content;
 
       // Rewrite section data with template content
-      utils.writeSectionData(store, newSection);
+      newSection.sectionPath = utils.writeSectionData(newStore, newSection);
     }
 
-    return store
+    return newStore
       .setIn(
         ['templates', requirePath],
         pairPath
       )
       .setIn(
-        ['sections', 'sectionsByPath', section.kssPath],
+        ['sections', 'sectionsByPath', newSection.kssPath],
         newSection
       )
       .setIn(
-        ['sections', 'sectionsByURI', section.referenceURI],
+        ['sections', 'sectionsByURI', newSection.referenceURI],
         newSection
       );
-  } else {
-    return store;
   }
+
+  return newStore;
 }
 
 /**
@@ -70,19 +71,21 @@ templateHandler.deleteTemplate = function(filepath, section, store) {
   const file = path.parse(filepath);
   const dest = path.resolve(cwd, huron.get('output'));
   const type = '.json' === file.ext ? 'data' : 'template';
+  const newSection = section;
+  let newStore = store;
 
   // Remove partner
-  let requirePath = utils.removeFile(section.referenceURI, type, filepath, store);
-  delete section[`${type}Path`];
+  let requirePath = utils.removeFile(newSection.referenceURI, type, filepath, newStore);
+  delete newSection[`${type}Path`];
 
-  return store
+  return newStore
     .deleteIn(['templates', requirePath])
     .setIn(
-      ['sections', 'sectionsByPath', section.kssPath],
-      section
+      ['sections', 'sectionsByPath', newSection.kssPath],
+      newSection
     )
     .setIn(
-      ['sections', 'sectionsByURI', section.referenceURI],
-      section
+      ['sections', 'sectionsByURI', newSection.referenceURI],
+      newSection
     );
 }

--- a/src/cli/require-templates.js
+++ b/src/cli/require-templates.js
@@ -60,7 +60,7 @@ function hotReplace(key, module, modules) {
     insert.cycleSections();
   } else {
     insert.inserted = [];
-    insert.loadModule(key, module);
+    insert.loadModule(key, module, false);
   }
 }
 

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -90,10 +90,10 @@ utils.normalizeHeader = function(header) {
  */
 utils.wrapMarkup = function(content, templateId) {
   return `<dom-module>
-    <template id="${templateId}">
-      ${content}
-    </template>
-  </dom-module>\n`;
+<template id="${templateId}">
+${content}
+</template>
+</dom-module>\n`;
 }
 
 /**

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -32,23 +32,23 @@ utils.writeSectionData = function(store, section, sectionPath = false) {
   let outputPath = sectionPath;
   let sectionFileInfo;
 
-  if (! outputPath) {
-    if ({}.hasOwnProperty.call(section, 'kssPath')) {
-      sectionFileInfo = path.parse(section.kssPath);
-      outputPath = path.join(sectionFileInfo.dir, `${sectionFileInfo.name}.json`);
-    } else {
-      return;
-    }
+  if (! outputPath && {}.hasOwnProperty.call(section, 'kssPath')) {
+    sectionFileInfo = path.parse(section.kssPath);
+    outputPath = path.join(sectionFileInfo.dir, `${sectionFileInfo.name}.json`);
   }
 
   // Output section data
-  return utils.writeFile(
-    section.referenceURI,
-    'section',
-    outputPath,
-    JSON.stringify(section),
-    store
-  );
+  if (outputPath) {
+    return utils.writeFile(
+      section.referenceURI,
+      'section',
+      outputPath,
+      JSON.stringify(section),
+      store
+    );
+  }
+
+  console.warn(chalk.red(`Failed to write section data for ${section.referenceURI}`));
 }
 
 /**

--- a/src/js/huron.js
+++ b/src/js/huron.js
@@ -40,14 +40,15 @@ class InsertNodes {
    */
   applyModifier(modifier, meta) {
     let rendered = false;
+    let data = meta.data;
 
-    if (meta.data) {
+    if (data) {
       // If we have a modifier, use it, otherwise use the entire data set
       if (modifier && meta.data[modifier]) {
-        rendered = meta.render(meta.data[modifier]);
-      } else {
-        rendered = meta.render(meta.data);
+        data = Object.assign({}, meta.data[modifier], {modifier});
       }
+
+      rendered = meta.render(data);
     } else {
       rendered = meta.render();
     }

--- a/templates/huron-wrapper.ejs
+++ b/templates/huron-wrapper.ejs
@@ -24,7 +24,7 @@
     </script>
   <% } %>
 </head>
-<body class="prototype">
+<body class="prototype prototype-<%= htmlWebpackPlugin.options.title %> <%= htmlWebpackPlugin.options.bodyClasses %>">
 <% if (htmlWebpackPlugin.options.unsupportedBrowser) { %>
 <style>.unsupported-browser { display: none; }</style>
 <div class="unsupported-browser">


### PR DESCRIPTION
...instead of looping through every single module in every template context. Fun fact: for a large style guide which includes examples of all KSS markup (~245 partials loaded as modules!) this feature reduced the number of calls to the `loadModule` function on initial page load from ~75000 to ~270. Page load is visibly faster.

- Also includes improvements to handling of changes to KSS data
- Adds modifier as a JSON data field for use in templates (via `{{ modifier}}`)
- Adds `prototype-[title]` class to default prototype template
- Adds ability to use a custom (not officially supported) `bodyClasses` field for HTMLWebpackPlugin to add custom classes to the prototype body tag
- Alphabetizes methods in the frontend `insertNodes` class